### PR TITLE
🔒 Fix: Missing rel="noopener noreferrer" on external links

### DIFF
--- a/app/admin/blogs/page.jsx
+++ b/app/admin/blogs/page.jsx
@@ -121,7 +121,11 @@ export default async function AdminBlogsPage() {
                     <div className="flex justify-end gap-2">
                       {post.status === "published" && (
                         <Button variant="ghost" size="sm" asChild>
-                          <Link href={`/blogs/${post.slug}`} target="_blank">
+                          <Link
+                            href={`/blogs/${post.slug}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
                             <Eye className="w-4 h-4" />
                           </Link>
                         </Button>

--- a/app/admin/reservations/[ref_id]/page.jsx
+++ b/app/admin/reservations/[ref_id]/page.jsx
@@ -57,6 +57,7 @@ const ReservationDetailPage = async ({ params }) => {
                   key={option.name}
                   href={option.url}
                   target="_blank"
+                  rel="noopener noreferrer"
                   className="border p-2 rounded-md hover:bg-muted"
                 >
                   {option.name}
@@ -77,6 +78,7 @@ const ReservationDetailPage = async ({ params }) => {
                   key={option.name}
                   href={option.url}
                   target="_blank"
+                  rel="noopener noreferrer"
                   className="border p-2 rounded-md hover:bg-muted"
                 >
                   {option.name}
@@ -97,6 +99,7 @@ const ReservationDetailPage = async ({ params }) => {
                   key={option.name}
                   href={option.url}
                   target="_blank"
+                  rel="noopener noreferrer"
                   className="border p-2 rounded-md hover:bg-muted"
                 >
                   {option.name}

--- a/components/Footer.jsx
+++ b/components/Footer.jsx
@@ -37,7 +37,12 @@ const Footer = () => {
               <h3 className="text-sm font-bold ">Follow Us on Social Media</h3>
               <div className="Socials flex gap-3 my-3">
                 {socialLinks.map((item, idx) => (
-                  <Link key={idx} href={item.url} target="_blank">
+                  <Link
+                    key={idx}
+                    href={item.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
                     <Image
                       src={item.icon}
                       width={24}
@@ -57,7 +62,11 @@ const Footer = () => {
       </div>
       <div className="flex bg-slate-900 justify-evenly flex-wrap gap-2 text-white text-sm text-center border border-x-0 border-b-0 px-4 py-1">
         <p className="">Virstravel &copy; 2025 All rights reserved.</p>
-        <Link href="https://uniiktheo.tech" target="_blank">
+        <Link
+          href="https://uniiktheo.tech"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           <p className="ml-2">Powered by Virstaf</p>
         </Link>
       </div>

--- a/components/LandingFooter.jsx
+++ b/components/LandingFooter.jsx
@@ -22,7 +22,12 @@ const LandingFooter = () => {
           <div className="">
             <div className="Socials flex gap-3 my-3">
               {socialLinks.map((item, idx) => (
-                <Link key={idx} href={item.url} target="_blank">
+                <Link
+                  key={idx}
+                  href={item.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
                   {/* <Image
                     src={item.iconSrc}
                     width={24}
@@ -51,6 +56,7 @@ const LandingFooter = () => {
           <Link
             href="https://virstaf.com/"
             target="_blank"
+            rel="noopener noreferrer"
             className="hover:text-secondary"
           >
             Virstaf LTD

--- a/components/contact7.jsx
+++ b/components/contact7.jsx
@@ -75,6 +75,7 @@ const ContactUs = ({
             <Link
               href="https://wa.me/447770939627"
               target="_blank"
+              rel="noopener noreferrer"
               className="font-semibold hover:underline"
             >
               {chatLink}

--- a/components/deal-detail.jsx
+++ b/components/deal-detail.jsx
@@ -271,7 +271,11 @@ export default function DealDetail({ deal, isPublic = false }) {
                   </p>
                   {deal.partners.website_url && (
                     <Button variant="link" className="p-0 h-auto" asChild>
-                      <Link href={deal.partners.website_url} target="_blank">
+                      <Link
+                        href={deal.partners.website_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
                         Visit Partner Website
                       </Link>
                     </Button>

--- a/components/travel-smarter.jsx
+++ b/components/travel-smarter.jsx
@@ -13,6 +13,7 @@ const TravelSmarter = () => {
         <Link
           className="hover:text-primary hover:underline"
           target="_blank"
+          rel="noopener noreferrer"
           href="https://www.caa.co.uk/atol-protection/"
         >
           ATOL

--- a/email-templates/confirm-reservation.jsx
+++ b/email-templates/confirm-reservation.jsx
@@ -37,6 +37,7 @@ const ReservationConfirmationEmail = ({ fullname, reservationLink, type }) => {
               <Container className="text-center my-8">
                 <Button
                   target="_blank"
+                  rel="noopener noreferrer"
                   href={reservationLink}
                   className="bg-primary text-white px-6 py-3 rounded-lg font-medium focus:outline-none focus:ring-2 focus:ring-primary/50"
                 >

--- a/email-templates/confirm-subscription.jsx
+++ b/email-templates/confirm-subscription.jsx
@@ -40,6 +40,7 @@ const SubscriptionEmail = ({ fullname, link, plan = "silver" }) => {
               <Container className="text-center my-8">
                 <Button
                   target="_blank"
+                  rel="noopener noreferrer"
                   href={link}
                   className="bg-primary text-white px-6 py-3 rounded-lg font-medium focus:outline-none focus:ring-2 focus:ring-primary/50"
                 >

--- a/email-templates/confirm-trip.jsx
+++ b/email-templates/confirm-trip.jsx
@@ -42,6 +42,7 @@ const TripConfirmationEmail = ({
               <Container className="text-center my-8">
                 <Button
                   target="_blank"
+                  rel="noopener noreferrer"
                   href={tripLink}
                   className="bg-primary text-white px-6 py-3 rounded-lg font-medium focus:outline-none focus:ring-2 focus:ring-primary/50"
                 >

--- a/email-templates/quote-acceptance.jsx
+++ b/email-templates/quote-acceptance.jsx
@@ -71,6 +71,7 @@ const QuoteAcceptanceEmail = ({ fullname, quoteDetails }) => {
               <Container className="text-center my-8">
                 <Button
                   target="_blank"
+                  rel="noopener noreferrer"
                   href={dashboardLink}
                   className="bg-blue-500 text-white px-6 py-3 rounded-lg font-medium focus:outline-none focus:ring-2 focus:ring-blue-500/50"
                 >

--- a/email-templates/quote-notification.jsx
+++ b/email-templates/quote-notification.jsx
@@ -84,6 +84,7 @@ const QuoteNotificationEmail = ({ fullname, quoteDetails }) => {
               <Container className="text-center my-8">
                 <Button
                   target="_blank"
+                  rel="noopener noreferrer"
                   href={`${dashboardLink}/${quoteNumber}`}
                   className="bg-blue-500 text-white px-6 py-3 rounded-lg font-medium focus:outline-none focus:ring-2 focus:ring-blue-500/50"
                 >

--- a/email-templates/reservation-admin.jsx
+++ b/email-templates/reservation-admin.jsx
@@ -76,6 +76,7 @@ const ReservationAdminEmail = ({ details, type, user }) => {
               <Container className="text-center my-8">
                 <Button
                   target="_blank"
+                  rel="noopener noreferrer"
                   href="https://virstravelclub.com/admin/"
                   className="bg-blue-500 text-white px-6 py-3 rounded-lg font-medium focus:outline-none focus:ring-2 focus:ring-blue-500/50"
                 >

--- a/email-templates/reservation-email.jsx
+++ b/email-templates/reservation-email.jsx
@@ -70,6 +70,7 @@ const ReservationEmail = ({ fullname, details, type }) => {
               <Container className="text-center my-8">
                 <Button
                   target="_blank"
+                  rel="noopener noreferrer"
                   href="https://virstravelclub.com/dashboard/"
                   className="bg-blue-500 text-white px-6 py-3 rounded-lg font-medium focus:outline-none focus:ring-2 focus:ring-blue-500/50"
                 >


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is the missing `rel="noopener noreferrer"` attribute on external links that use `target="_blank"`.
⚠️ **Risk:** Without this attribute, the opened page can control the original page via `window.opener`, which could lead to "tabnabbing" attacks.
🛡️ **Solution:** Added `rel="noopener noreferrer"` to all `Link` and `Button` components that use `target="_blank"` across the codebase, including deal details, footers, admin pages, and email templates.

---
*PR created automatically by Jules for task [10135508860330940114](https://jules.google.com/task/10135508860330940114) started by @uniquetheo*