### PR TITLE
🔒 Fix SQL Injection vulnerability in deals search

### DIFF
--- a/actions/deals.js
+++ b/actions/deals.js
@@ -59,7 +59,10 @@ export const getDealsAction = async ({
 
     // Destination filter
     if (dest) {
-      query = query.or(`location.ilike.%${dest}%,title.ilike.%${dest}%`);
+      // Escape backslashes, wildcards, and double quotes to prevent filter injection
+      const safeDest = dest.replace(/[\\%_"]/g, '\\$&');
+      // Wrap in double quotes to handle potential commas in the destination string
+      query = query.or(`location.ilike."%${safeDest}%",title.ilike."%${safeDest}%"`);
     }
 
     // Max Price filter


### PR DESCRIPTION
🎯 **What:** Fixed a filter injection vulnerability in the Supabase deals query.
⚠️ **Risk:** Without escaping, attackers could inject commas and wildcard characters (`%`, `_`) into the `dest` parameter to prematurely end the current `ilike` clause and start a new malformed one, allowing arbitrary filtering or wildcard injection.
🛡️ **Solution:** The `dest` input now correctly escapes double quotes, backslashes, and wildcard characters, and its value is wrapped in double quotes inside the `.or()` query string to ensure commas and other values are parsed as a string literal instead of filter syntax separators.

---
*PR created automatically by Jules for task [14352421448660891869](https://jules.google.com/task/14352421448660891869) started by @uniquetheo*