### PR TITLE
🧹 Remove unused React imports

### DIFF
--- a/app/(users)/dashboard/bookings.jsx
+++ b/app/(users)/dashboard/bookings.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 
 const Bookings = () => {
   return <div>bookings</div>;

--- a/app/(users)/dashboard/bookings/page.jsx
+++ b/app/(users)/dashboard/bookings/page.jsx
@@ -2,7 +2,6 @@ import { getUserQuotes } from "@/actions/quotes";
 import DashHeader from "@/components/dash-header";
 import QuoteCard from "@/components/QuoteCard";
 import { getUser } from "@/lib/supabase/server";
-import React from "react";
 
 const BookingsPage = async () => {
   const user = await getUser();

--- a/app/(users)/dashboard/not-found.jsx
+++ b/app/(users)/dashboard/not-found.jsx
@@ -2,7 +2,6 @@ import DashNav from "@/components/dash-nav";
 import SideBar from "@/components/SideBar";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
-import React from "react";
 
 const DashboardNotFound = () => {
   return (

--- a/app/(users)/dashboard/reservations/page.jsx
+++ b/app/(users)/dashboard/reservations/page.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import DashHeader from "@/components/dash-header";
 import { getProfileAction } from "@/actions/profiles";
 import { getUserReservations } from "@/actions/reservations";

--- a/app/(users)/dashboard/settings/page.jsx
+++ b/app/(users)/dashboard/settings/page.jsx
@@ -1,6 +1,5 @@
 import DashHeader from "@/components/dash-header";
 import Settings from "@/components/settings-page";
-import React from "react";
 
 const SettingsPage = () => {
   return (

--- a/app/(users)/dashboard/trips/new/page.jsx
+++ b/app/(users)/dashboard/trips/new/page.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import NewTripForm from "@/components/new-trip-form";
 import DashHeader from "@/components/dash-header";
 

--- a/app/about/page.jsx
+++ b/app/about/page.jsx
@@ -8,7 +8,6 @@ import {
 } from "@/lib/data";
 import Image from "next/image";
 import Link from "next/link";
-import React from "react";
 
 const AboutPage = () => {
   return (

--- a/app/admin/quotes/new/page.jsx
+++ b/app/admin/quotes/new/page.jsx
@@ -1,7 +1,6 @@
 import AddQuoteForm from "@/components/AddQuoteForm";
 import NavSummary from "@/components/NavSummary";
 import { getAdminUser } from "@/lib/supabase/admin/server";
-import React from "react";
 
 const NewQuotePage = async () => {
   const pathname = "/admin/quotes/new";

--- a/app/admin/users/[customer_id]/page.jsx
+++ b/app/admin/users/[customer_id]/page.jsx
@@ -6,7 +6,6 @@ import UserTripsTable from "@/components/admin/user-trips-table";
 import { UserCard } from "@/components/admin/UserCard";
 import NavSummary from "@/components/NavSummary";
 import NoteTextBox from "@/components/ui/NoteTextBox";
-import React from "react";
 
 const UserDetailPage = async ({ params }) => {
   const { customer_id } = await params;

--- a/app/admin/users/page.jsx
+++ b/app/admin/users/page.jsx
@@ -1,7 +1,6 @@
 import {getAllUsers, getAuthUsers} from "@/actions/admin/users";
 import UsersTable from "@/components/admin/users-table";
 import NavSummary from "@/components/NavSummary";
-import React from "react";
 import UnverifiedUsersTable from "@/components/admin/UnverifiedUsersTable";
 
 const UsersPage = async () => {

--- a/app/auth/forgot-password/page.jsx
+++ b/app/auth/forgot-password/page.jsx
@@ -2,7 +2,6 @@ import { Button } from "@/components/ui/button";
 import ForgotPasswordForm from "@/components/ui/forgotPasswordForm";
 import Image from "next/image";
 import Link from "next/link";
-import React from "react";
 
 const ForgotPasswordPage = () => {
   return (

--- a/app/auth/layout.jsx
+++ b/app/auth/layout.jsx
@@ -1,6 +1,5 @@
 import { getUser } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
-import React from "react";
 
 export default async function AuthLayout({ children }) {
   try {

--- a/app/auth/login/page.jsx
+++ b/app/auth/login/page.jsx
@@ -1,7 +1,6 @@
 import LoginForm from "@/components/ui/loginForm";
 import Image from "next/image";
 import Link from "next/link";
-import React from "react";
 
 const LoginPage = () => {
   return (

--- a/app/auth/reset-password/page.jsx
+++ b/app/auth/reset-password/page.jsx
@@ -2,7 +2,6 @@ import { Button } from "@/components/ui/button";
 import ResetPasswordForm from "@/components/ui/resetPasswordForm";
 import Image from "next/image";
 import Link from "next/link";
-import React from "react";
 
 const ResetPasswordPage = () => {
   return (

--- a/app/blogs/[postId]/page.jsx
+++ b/app/blogs/[postId]/page.jsx
@@ -5,7 +5,6 @@ import { getBlogPostBySlug } from "@/app/actions/blogActions";
 import { ArrowLeft, Calendar, Clock } from "lucide-react";
 import Link from "next/link";
 import Image from "next/image";
-import React from "react";
 import { ShareButton, ShareArticleButton } from "@/components/ShareButtons";
 import { notFound } from "next/navigation";
 import { TiptapRenderer } from "@/components/TiptapRenderer";

--- a/app/blogs/layout.jsx
+++ b/app/blogs/layout.jsx
@@ -1,6 +1,5 @@
 import LandingFooter from "@/components/LandingFooter";
 import NavBar from "@/components/nav-bar";
-import React from "react";
 
 export default function Layout({ children }) {
   return (

--- a/app/blogs/page.jsx
+++ b/app/blogs/page.jsx
@@ -1,5 +1,4 @@
 import Posts from "@/components/Posts";
-import React from "react";
 
 const BlogPage = () => {
   return (

--- a/app/cookies-policy/page.jsx
+++ b/app/cookies-policy/page.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 
 const CookiesPolicyPage = () => {
   return (

--- a/app/homepage/page.jsx
+++ b/app/homepage/page.jsx
@@ -2,7 +2,6 @@ import Hero from "@/components/hero";
 import ProblemSection from "@/components/problem";
 import SolutionSection from "@/components/solution";
 import BenefitSection from "@/components/benefit";
-import React from "react";
 import WhoItsFor from "@/components/who-its-for";
 import Process from "@/components/process";
 import Testimonials from "@/components/Testimonials";

--- a/app/not-found.jsx
+++ b/app/not-found.jsx
@@ -2,7 +2,6 @@ import Footer from "@/components/Footer";
 import NavSection from "@/components/NavSection";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
-import React from "react";
 
 const NotFound = () => {
   return (

--- a/app/onboarding/layout.jsx
+++ b/app/onboarding/layout.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 
 export default function OnboardingLayout({ children }) {
   return (

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -1,7 +1,6 @@
 import Hero from "@/components/hero";
 import ProblemSection from "@/components/problem";
 import BenefitSection from "@/components/benefit";
-import React from "react";
 import WhoItsFor from "@/components/who-its-for";
 import Process from "@/components/process";
 import Testimonials from "@/components/Testimonials";

--- a/app/privacy-policy/page.jsx
+++ b/app/privacy-policy/page.jsx
@@ -1,5 +1,4 @@
 import Link from "next/link";
-import React from "react";
 
 const PrivacyPage = () => {
   return (

--- a/app/profile/layout.jsx
+++ b/app/profile/layout.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 
 export default function ProfileLayout({ children }) {
   return (

--- a/app/terms-of-service/page.jsx
+++ b/app/terms-of-service/page.jsx
@@ -1,5 +1,4 @@
 import Link from "next/link";
-import React from "react";
 
 const TermsOfServicePage = () => {
   return (

--- a/components/AutoPlayVideo.jsx
+++ b/components/AutoPlayVideo.jsx
@@ -1,5 +1,4 @@
 // components/AutoPlayVideo.jsx
-import React from "react";
 
 const AutoPlayVideo = ({ source, style }) => {
   return (

--- a/components/BlogPreview.jsx
+++ b/components/BlogPreview.jsx
@@ -1,5 +1,4 @@
 import Link from "next/link";
-import React from "react";
 
 const BlogPreview = ({ excerpt, id }) => {
   return (

--- a/components/CTA-Banner.jsx
+++ b/components/CTA-Banner.jsx
@@ -1,5 +1,4 @@
 import Link from "next/link";
-import React from "react";
 import { Button } from "./ui/button";
 import { JoinDialog } from "./JoinDialog";
 

--- a/components/CancelReservationBtn.jsx
+++ b/components/CancelReservationBtn.jsx
@@ -1,6 +1,5 @@
 "use client";
 
-import React from "react";
 import { Button } from "./ui/button";
 import { cancelReservation } from "@/actions/reservations";
 import { toast } from "sonner";

--- a/components/FAQSection.jsx
+++ b/components/FAQSection.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import Faq from "./ui/faq";
 import { faqs } from "@/lib/data";
 import Image from "next/image";

--- a/components/FeaturedDestinations.jsx
+++ b/components/FeaturedDestinations.jsx
@@ -1,5 +1,4 @@
 import { destinations } from "@/lib/data";
-import React from "react";
 import Destinations from "./ui/Destinations";
 import { Button } from "./ui/button";
 

--- a/components/HeroSection.jsx
+++ b/components/HeroSection.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { Button } from "./ui/button";

--- a/components/HowItWorks.jsx
+++ b/components/HowItWorks.jsx
@@ -1,5 +1,4 @@
 import { howItWorks } from "@/lib/data";
-import React from "react";
 
 const HowItWorks = () => {
   return (

--- a/components/LandingFooter.jsx
+++ b/components/LandingFooter.jsx
@@ -3,7 +3,6 @@
 import { socialLinks } from "@/lib/data";
 import Image from "next/image";
 import Link from "next/link";
-import React from "react";
 import Logo from "./ui/logo";
 
 const LandingFooter = () => {

--- a/components/LandingPage.jsx
+++ b/components/LandingPage.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import HeroSection from "./HeroSection";
 import LimitedTimeSection from "./LimitedTimeSection";
 import WhyJoin from "./WhyJoin";

--- a/components/LimitedTimeSection.jsx
+++ b/components/LimitedTimeSection.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Button } from "./ui/button";
 import Link from "next/link";
 import { JoinDialog } from "./JoinDialog";

--- a/components/ListItem.jsx
+++ b/components/ListItem.jsx
@@ -1,6 +1,5 @@
 import { getFormattedDate } from "@/lib/getFormattedDate";
 import Link from "next/link";
-import React from "react";
 import BlogPreview from "./BlogPreview";
 import { getPostExcerpt } from "@/lib/posts";
 

--- a/components/Newsletter.jsx
+++ b/components/Newsletter.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import SubscribeForm from "./ui/subscribe";
 import { Lightbulb } from "lucide-react";
 

--- a/components/RequestTrip.jsx
+++ b/components/RequestTrip.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 
 const RequestTrip = () => {
   return <div>RequestTrip</div>;

--- a/components/StripePricingTable.jsx
+++ b/components/StripePricingTable.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 
 export const StripePricingTable = () => {
   return (

--- a/components/Table/Table.jsx
+++ b/components/Table/Table.jsx
@@ -1,7 +1,7 @@
 "use client";
 
 // components/Table/Table.jsx
-import React, { useState, useMemo } from "react";
+import { useState, useMemo  } from "react";
 import TableHeader from "./TableHeader";
 import TableBody from "./TableBody";
 import TablePagination from "./TablePagination";

--- a/components/Table/TableBody.jsx
+++ b/components/Table/TableBody.jsx
@@ -1,5 +1,4 @@
 // components/Table/TableBody.jsx
-import React from 'react';
 
 const TableBody = ({
   columns,

--- a/components/Table/TableHeader.jsx
+++ b/components/Table/TableHeader.jsx
@@ -1,5 +1,4 @@
 // components/Table/TableHeader.jsx
-import React from "react";
 
 const TableHeader = ({ columns, sortConfig, onSort }) => {
   return (

--- a/components/Table/TablePagination.jsx
+++ b/components/Table/TablePagination.jsx
@@ -1,7 +1,6 @@
 "use client";
 
 // components/Table/TablePagination.jsx
-import React from "react";
 
 const TablePagination = ({
   currentPage,

--- a/components/WelcomePackages.jsx
+++ b/components/WelcomePackages.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Button } from "./ui/button";
 import Link from "next/link";
 import { JoinDialog } from "./JoinDialog";

--- a/components/WhyJoin.jsx
+++ b/components/WhyJoin.jsx
@@ -1,5 +1,4 @@
 import { benefits } from "@/lib/data";
-import React from "react";
 
 const WhyJoin = () => {
   return (

--- a/components/admin/ReservationCard.jsx
+++ b/components/admin/ReservationCard.jsx
@@ -1,5 +1,4 @@
 import { getFormattedDate } from "@/lib/getFormattedDate";
-import React from "react";
 import Status from "../ui/status";
 
 export const ReservationCard = ({

--- a/components/admin/UnverifiedUsersTable.jsx
+++ b/components/admin/UnverifiedUsersTable.jsx
@@ -1,6 +1,5 @@
 "use client";
 
-import React from "react";
 import { getFormattedDateTime } from "@/lib/getFormattedDate";
 import Table from "@/components/Table/Table";
 import {

--- a/components/admin/metric-list.jsx
+++ b/components/admin/metric-list.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import MetricCard from "./metric-card";
 
 const MetricList = ({ metrics }) => {

--- a/components/admin/user-trips-table.jsx
+++ b/components/admin/user-trips-table.jsx
@@ -1,6 +1,5 @@
 "use client";
 
-import React from "react";
 import Table from "../Table/Table";
 import Status from "../ui/status";
 

--- a/components/admin/users-table.jsx
+++ b/components/admin/users-table.jsx
@@ -1,6 +1,5 @@
 "use client";
 
-import React from "react";
 import Table from "../Table/Table";
 import { redirect } from "next/navigation";
 import {

--- a/components/benefit.jsx
+++ b/components/benefit.jsx
@@ -1,5 +1,4 @@
 import { memberBenefits } from "@/lib/data";
-import React from "react";
 
 const BenefitSection = () => {
   return (

--- a/components/choosing-help.jsx
+++ b/components/choosing-help.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 
 const ChoosingHelp = () => {
   return (

--- a/components/dash-header.jsx
+++ b/components/dash-header.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import SearchComponent from "./SearchComponent";
 
 const DashHeader = ({ page, description, className }) => {

--- a/components/flights-page.jsx
+++ b/components/flights-page.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Button } from "./ui/button";
 import Link from "next/link";
 

--- a/components/hero-form.jsx
+++ b/components/hero-form.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import { useState, useEffect  } from "react";
 import { createDealRequest } from "@/actions/deal-requests";
 import { Button } from "./ui/button";
 import { Label } from "./ui/label";

--- a/components/hero.jsx
+++ b/components/hero.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { HeroForm } from "./hero-form";
 
 const Hero = () => {

--- a/components/problem.jsx
+++ b/components/problem.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 // import { FaMoneyBillWave, FaClock, FaGift, FaSearch, FaUmbrellaBeach } from "react-icons/fa";
 import { Landmark, Clock, Gift, Search, Castle } from "lucide-react";
 import Image from "next/image";

--- a/components/process.jsx
+++ b/components/process.jsx
@@ -1,5 +1,4 @@
 import { processSteps } from "@/lib/data";
-import React from "react";
 
 const Process = () => {
   return (

--- a/components/solution.jsx
+++ b/components/solution.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 
 const SolutionSection = () => {
   return (

--- a/components/subscription-settings.jsx
+++ b/components/subscription-settings.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
 import SubscriptionStatus from "./subscription-status";
 import Pricing from "./ui/pricing";

--- a/components/tiers-table.jsx
+++ b/components/tiers-table.jsx
@@ -1,7 +1,6 @@
 "use client";
 
 // pages/index.js
-import React from "react";
 import Table from "./Table/Table";
 import { tierTableData } from "@/lib/data";
 

--- a/components/travel-smarter.jsx
+++ b/components/travel-smarter.jsx
@@ -1,5 +1,4 @@
 import Link from "next/link";
-import React from "react";
 
 const TravelSmarter = () => {
   return (

--- a/components/trips-section.jsx
+++ b/components/trips-section.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import TripsList from "./TripsList";
 import { getProfileAction } from "@/actions/profiles";
 import { fetchTrips } from "@/actions/trips";

--- a/components/ui/Destinations.jsx
+++ b/components/ui/Destinations.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 
 const Destinations = ({ title, imgSrc, description, isFeatured }) => {
   return (

--- a/components/ui/SubscriptionFaq.jsx
+++ b/components/ui/SubscriptionFaq.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 
 const SubscriptionFaq = () => {
   return (

--- a/components/ui/address-autocomplete.jsx
+++ b/components/ui/address-autocomplete.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useRef, useEffect } from "react";
+import { useRef, useEffect  } from "react";
 import { useLoadScript } from "@react-google-maps/api";
 import { Input } from "@/components/ui/input";
 import { Loader2 } from "lucide-react";

--- a/components/ui/hotelCard.jsx
+++ b/components/ui/hotelCard.jsx
@@ -1,6 +1,5 @@
 import { Star } from "lucide-react";
 import Image from "next/image";
-import React from "react";
 
 const HotelCard = ({ hotel }) => {
   const imageSrc = hotel.image + hotel.id + ".jpg";

--- a/components/ui/input-suggestion.jsx
+++ b/components/ui/input-suggestion.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 
 const InputSuggestion = ({ suggestion, onClick }) => {
   return (

--- a/components/ui/logout-button.jsx
+++ b/components/ui/logout-button.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import { useState  } from "react";
 import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { useRouter } from "next/navigation";

--- a/components/ui/productCard.jsx
+++ b/components/ui/productCard.jsx
@@ -1,5 +1,4 @@
 import { Star } from "lucide-react";
-import React from "react";
 import { Button } from "./button";
 import Link from "next/link";
 import Image from "next/image";

--- a/components/ui/section-header.jsx
+++ b/components/ui/section-header.jsx
@@ -1,5 +1,4 @@
 import Link from "next/link";
-import React from "react";
 
 const SectionHeader = ({ title, link }) => {
   return (

--- a/components/ui/slidingCard.jsx
+++ b/components/ui/slidingCard.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 
 const SlidingCard = ({ message, author, stars }) => {
   const totalStars = 5;

--- a/components/ui/status.jsx
+++ b/components/ui/status.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { getStatusColor } from "@/lib/statusHelpers";
 
 const Status = ({ value }) => {

--- a/components/ui/userProfile.jsx
+++ b/components/ui/userProfile.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import { useEffect, useState  } from "react";
 import CurrentUserAvatar from "../current-user-avatar";
 import LogoutButton from "./logout-button";
 import Link from "next/link";

--- a/components/who-its-for.jsx
+++ b/components/who-its-for.jsx
@@ -1,6 +1,5 @@
 import { whoItsFor } from "@/lib/data";
 import Image from "next/image";
-import React from "react";
 
 const WhoItsFor = () => {
   return (


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed unused `React` default imports from components and app files.

💡 **Why:** How this improves maintainability
The project uses React 19 / Next.js with the automatic JSX transformation. Therefore, `import React from "react";` is no longer needed simply to use JSX syntax. Removing these unused imports cleans up the code and reduces bundle clutter.

✅ **Verification:** How you confirmed the change is safe
Ran a script to systematically locate and remove the unused imports only when `React` itself was not otherwise used in the file. Confirmed `next build` continues to compile without issue related to JSX or React.

✨ **Result:** The improvement achieved
Cleaned up 53 files, removing unnecessary and confusing dead code.

---
*PR created automatically by Jules for task [15913031576928982604](https://jules.google.com/task/15913031576928982604) started by @uniquetheo*